### PR TITLE
mobile layout for invoice download and signing

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,8 +10,25 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 body {
   background-color: #F9F9F9;
+}
+@media (max-width: 650px), (max-height: 500px) {
+  .wizard-navigation .wizard-nav.wizard-nav-pills .stepTitle {
+    display: none;
+  }
+  .vue-form-wizard .wizard-header {
+    padding: .2em;
+  }
+  .vue-form-wizard .wizard-tab-content {
+    padding: 1em 0;
+  }
+  .vue-form-wizard .wizard-card-footer {
+    flex-direction: row;
+    .wizard-footer-right button {
+      margin-top: 0;
+    }
+  }
 }
 </style>

--- a/frontend/src/components/invoice-summary/InvoiceSummary.vue
+++ b/frontend/src/components/invoice-summary/InvoiceSummary.vue
@@ -182,4 +182,13 @@ export default {
     color: rgba(20, 20, 20, 0.5);
   }
 }
+
+@media (max-width: 650px), (max-height: 500px) {
+  .invoice {
+    width: 100vw;
+    margin: 0;
+    padding-bottom: 1em;
+  }
+}
+
 </style>

--- a/frontend/src/components/invoice-summary/steps/DownloadContract.vue
+++ b/frontend/src/components/invoice-summary/steps/DownloadContract.vue
@@ -45,4 +45,9 @@ export default {
     }
   }
 }
+@media (max-width: 650px), (max-height: 500px) {
+  .content {
+    padding: 1em 0;
+  }
+}
 </style>

--- a/frontend/src/components/invoice-summary/steps/SignContract.vue
+++ b/frontend/src/components/invoice-summary/steps/SignContract.vue
@@ -57,4 +57,9 @@
 .contract-files-input {
   display: none;
 }
+@media (max-width: 650px), (max-height: 500px) {
+  .content {
+    padding: 1em 10px;
+  }
+}
 </style>


### PR DESCRIPTION
Layout changes to make incoive download, signing and payment sections mobile friendly. Screenshots show screensize of iphone 5:
![invoice_step_1](https://user-images.githubusercontent.com/246402/30062137-631f1700-924a-11e7-8c48-5076d38f3de6.jpg)
![invoice_step_2](https://user-images.githubusercontent.com/246402/30062138-6321f9e8-924a-11e7-812c-77c5fca36a2d.jpg)
![invoice_step_3](https://user-images.githubusercontent.com/246402/30062136-631c3184-924a-11e7-9d7d-6db1fe3a6b0c.jpg)

