### PR TITLE
Mobile layout create invoice

### DIFF
--- a/frontend/src/components/portal/CreateInvoice.vue
+++ b/frontend/src/components/portal/CreateInvoice.vue
@@ -4,7 +4,8 @@
       <div class="container">
         <div class="pull-left title">
           <router-link to="/">Invoices</router-link> /
-          <span class="text-muted">Contract ID {{contractId}}</span>
+          <span class="hidden-xs text-muted">Contract ID</span>
+          <span class="text-muted">{{contractId}}</span>
         </div>
       </div>
     </div>
@@ -219,7 +220,8 @@ export default {
 
 .upload-files {
   padding: 40px;
-  width: 400px;
+  max-width: 400px;
+  width: calc(100vw - 30px);
   text-align: center;
   border: 2px dotted #979797;
 
@@ -239,7 +241,8 @@ export default {
 
 .btn-toolbar {
   border-top: 1px solid #000;
-  width: 400px;
+  max-width: 400px;
+  width: calc(100vw - 30px);
   padding: 30px 0;
 }
 

--- a/frontend/src/components/portal/InvoicesManager.vue
+++ b/frontend/src/components/portal/InvoicesManager.vue
@@ -217,20 +217,26 @@ export default {
 }
 
 .create-title {
-	color: #141414;
-	font-family: "Open Sans";
-	font-size: 22px;
-	font-weight: 600;
+  color: #141414;
+  font-family: "Open Sans";
+  font-size: 22px;
+  font-weight: 600;
   margin: 15px 0;
 }
 
 .create-subtitle {
-	opacity: 0.5;
-	color: #141414;
-	font-family: "Open Sans";
-	font-size: 18px;
-	line-height: 24px;
-	text-align: center;
+  opacity: 0.5;
+  color: #141414;
+  font-family: "Open Sans";
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
   margin: 15px 0;
+}
+
+@media (max-width: 650px), (max-height: 500px) {
+  .empty-table {
+    margin-top: 20px;
+  }
 }
 </style>

--- a/frontend/src/components/portal/redeem-invoice/RedeemInvoice.vue
+++ b/frontend/src/components/portal/redeem-invoice/RedeemInvoice.vue
@@ -4,7 +4,8 @@
       <div class="container">
         <div class="pull-left title">
           <router-link to="/">Invoices</router-link> /
-          <span class="text-muted">Contract ID {{ contractId }}</span>
+          <span class="hidden-xs text-muted">Contract ID</span>
+          <span class="text-muted">{{contractId}}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Layout changes to make invoice creation section mobile friendly. Screenshots show screensize of iphone 5:

![create_step_1_1](https://user-images.githubusercontent.com/246402/30078709-72ccc970-927e-11e7-8f3c-b5bae649c3fd.jpg)
![create_step_1_2](https://user-images.githubusercontent.com/246402/30078708-72c9d846-927e-11e7-839b-3ed7f633c4e9.jpg)
