### PR TITLE
Mobile layout redeem invoice

### DIFF
--- a/frontend/src/components/portal/CreateInvoice.vue
+++ b/frontend/src/components/portal/CreateInvoice.vue
@@ -207,10 +207,15 @@ export default {
 }
 
 .subnav .title {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: #36373A;
   font-family: "Open Sans";
   font-size: 20px;
   font-weight: bold;
+
 }
 
 .subnav .new-invoice-btn {

--- a/frontend/src/components/portal/ViewInvoice.vue
+++ b/frontend/src/components/portal/ViewInvoice.vue
@@ -114,6 +114,10 @@ export default {
 }
 
 .subnav .title {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: #36373A;
   font-family: "Open Sans";
   font-size: 20px;

--- a/frontend/src/components/portal/ViewInvoice.vue
+++ b/frontend/src/components/portal/ViewInvoice.vue
@@ -4,7 +4,9 @@
     <div class="subnav">
       <div class="container">
         <div class="pull-left title">
-          <router-link to="/">Invoices</router-link> / <span class="text-muted">Contract ID {{ contractId }}</span>
+          <router-link to="/">Invoices</router-link> /
+          <span class="text-muted hidden-xs">Contract ID</span>
+          <span class="text-muted">{{ contractId }}</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/portal/redeem-invoice/CompleteTransaction.vue
+++ b/frontend/src/components/portal/redeem-invoice/CompleteTransaction.vue
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="row copy-button">
-      <div class="col-xs-4 col-xs-offset-4">
+      <div class="col-xs-8 col-sm-4 col-xs-offset-2 col-sm-offset-4">
         <!-- <label class="pure-button btn-file">
           <i class="fa fa-files-o"></i> Copy Link
         </label> -->
@@ -105,6 +105,11 @@ export default {
 
   .btc-amount {
     margin-bottom: 10px;
+  }
+}
+@media (max-width: 650px), (max-height: 500px) {
+  .content .copy-button {
+    margin-bottom: 1em;
   }
 }
 </style>

--- a/frontend/src/components/portal/redeem-invoice/RedeemInvoice.vue
+++ b/frontend/src/components/portal/redeem-invoice/RedeemInvoice.vue
@@ -193,6 +193,10 @@ export default {
 }
 
 .subnav .title {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: #36373A;
   font-family: "Open Sans";
   font-size: 20px;

--- a/frontend/src/components/portal/redeem-invoice/RedeemInvoice.vue
+++ b/frontend/src/components/portal/redeem-invoice/RedeemInvoice.vue
@@ -4,7 +4,8 @@
       <div class="container">
         <div class="pull-left title">
           <router-link to="/">Invoices</router-link> /
-          <span class="text-muted">Contract ID {{ contractId }}</span>
+          <span class="text-muted hidden-xs">Contract ID</span>
+          <span class="text-muted">{{ contractId }}</span>
         </div>
       </div>
     </div>
@@ -218,5 +219,13 @@ export default {
   border-radius: 3px;
   background-color: #FFFFFF;
   box-shadow: 0 2px 7px 0 rgba(0, 0, 0, 0.25);
+}
+
+@media (max-width: 650px), (max-height: 500px) {
+  .invoice {
+    width: 100vw;
+    margin: 0;
+    padding-bottom: 1em;
+  }
 }
 </style>

--- a/frontend/src/components/portal/redeem-invoice/UploadContract.vue
+++ b/frontend/src/components/portal/redeem-invoice/UploadContract.vue
@@ -51,7 +51,8 @@ export default {
 
   .upload-files {
     padding: 40px;
-    width: 400px;
+    max-width: 400px;
+    width: calc(100vw - 30px);
     text-align: center;
     border: 2px dotted #979797;
 
@@ -71,6 +72,11 @@ export default {
 
   .contract-files-input {
     display: none;
+  }
+}
+@media (max-width: 650px), (max-height: 500px) {
+  .content {
+    padding: 1em 10px;
   }
 }
 </style>


### PR DESCRIPTION
Layout changes to make invoice redeem section mobile friendly. Also adds a fix for most of the sub-nav titles in case they are getting too long on a very small screen. Screenshots show screensize of iphone 5:
![redeem_step_1](https://user-images.githubusercontent.com/246402/30079035-233506ba-927f-11e7-9fc3-7fd789afd0eb.jpg)
![redeem_step_2](https://user-images.githubusercontent.com/246402/30079036-2339a9f4-927f-11e7-849f-bfd4d6125273.jpg)

